### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CC=g++ -std=c++11
-CFLAGS= -g -Wall -Werror -O2
+CXX = g++ -std=c++11
+CXXFLAGS = -g -Wall -Werror -O2
 
 INC=-I./include
 SRC=./src
@@ -23,16 +23,13 @@ print-%  : ; @echo $* = $($*)
 all: wotop
 
 wotop: $(OBJFILES)
-	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS) $(INC) -lpthread
+	$(CXX) $(LDFLAGS) -o $@ $^ $(LDLIBS) $(INC) -lpthread
 
 $(OBJ):
 	mkdir -p $(OBJ)
 
-$(OBJ)/%.o: $(SRC)/%.c | $(OBJ)
-	$(CC) $(DEBUG) -c $< -o $@ $(INC)
-
 $(OBJ)/%.o: $(SRC)/%.cpp | $(OBJ)
-	$(CC) $(DEBUG) -c $< -o $@ $(INC)
+	$(CXX) $(DEBUG) -c $< -o $@ $(INC)
 
 .PHONY: install
 install: wotop

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = g++ -std=c++11
-CXXFLAGS = -g -Wall -Wextra -Werror -O2
+CXXFLAGS = -g -Wall -Wextra -Wpedantic -Werror -O2
 
 INC=-I./include
 SRC=./src

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ INC=-I./include
 SRC=./src
 OBJ=bin
 
+PREFIX ?= /usr/local
+
 # Available flags:
 # DEBUG: DEBUG outputs from my code
 # DEBUG_PROXY: DEBUG outputs from the request parsing
@@ -13,27 +15,30 @@ OBJ=bin
 DEBUG=
 
 
-SRCFILES=$(addprefix $(OBJ)/, $(subst .c,.o, $(subst .cpp,.o, $(subst $(SRC)/,,$(wildcard $(SRC)/*)))))
+OBJFILES=$(addprefix $(OBJ)/, $(subst .c,.o, $(subst .cpp,.o, $(subst $(SRC)/,,$(wildcard $(SRC)/*)))))
 
 print-%  : ; @echo $* = $($*)
 
-all:
-	make clean
-	mkdir $(OBJ)
-	make proxy
+.PHONY: all
+all: wotop
 
-proxy: $(SRCFILES)
-	mkdir -p $(OBJ)
-	$(CC) $(LDFLAGS) -o wotop $(SRCFILES) $(LDLIBS) $(INC) -lpthread
+wotop: $(OBJFILES)
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS) $(INC) -lpthread
 
-$(OBJ)/%.o: $(SRC)/%.c
+$(OBJ):
 	mkdir -p $(OBJ)
+
+$(OBJ)/%.o: $(SRC)/%.c | $(OBJ)
 	$(CC) $(DEBUG) -c $< -o $@ $(INC)
 
-$(OBJ)/%.o: $(SRC)/%.cpp
-	mkdir -p $(OBJ)
+$(OBJ)/%.o: $(SRC)/%.cpp | $(OBJ)
 	$(CC) $(DEBUG) -c $< -o $@ $(INC)
 
+.PHONY: install
+install: wotop
+	install -Dm755 wotop $(DESTDIR)$(PREFIX)/bin/wotop
+
+.PHONY: clean
 clean:
 	rm -rf $(OBJ)
 	rm -f wotop

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(OBJ):
 	mkdir -p $(OBJ)
 
 $(OBJ)/%.o: $(SRC)/%.cpp | $(OBJ)
-	$(CXX) $(DEBUG) -c $< -o $@ $(INC)
+	$(CXX) $(CXXFLAGS) $(DEBUG) -c $< -o $@ $(INC)
 
 .PHONY: install
 install: wotop

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = g++ -std=c++11
-CXXFLAGS = -g -Wall -Werror -O2
+CXXFLAGS = -g -Wall -Wextra -Werror -O2
 
 INC=-I./include
 SRC=./src

--- a/include/logger.h
+++ b/include/logger.h
@@ -6,13 +6,10 @@
 #include <mutex>
 
 enum LogLevel { DEBUG, VERB2, VERB1, INFO, WARN, ERROR};
-static const char *logStrings[] =
-    { "DEBUG", "VERB2", "VERB1", "INFO ", "WARN ", "ERROR" };
 
 const LogLevel logLevel = WARN;
 
 class logIt {
-    LogLevel level;
 public:
     logIt(LogLevel l);
     logIt(LogLevel l, const char *s);

--- a/include/logger.h
+++ b/include/logger.h
@@ -28,7 +28,6 @@ private:
     static std::mutex llock;
 };
 
-#define GET_MACRO(_1,_2,NAME,...) NAME
-#define logger(...) GET_MACRO(__VA_ARGS__, logIt, logIt)(__VA_ARGS__)
+#define logger(...) logIt(__VA_ARGS__)
 
 #endif

--- a/include/logger.h
+++ b/include/logger.h
@@ -15,7 +15,7 @@ public:
     logIt(LogLevel l, const char *s);
 
     template <typename T>
-    logIt & operator<<(T const & value) {
+    logIt & operator<<(T const & value __attribute__((unused))) {
         // _buffer << value;
         return *this;
     }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -2,6 +2,9 @@
 #include <iostream>
 #include <sstream>
 
+static const char *logStrings[] =
+    { "DEBUG", "VERB2", "VERB1", "INFO ", "WARN ", "ERROR" };
+
 std::mutex logIt::llock;
 std::ostringstream logIt::_buffer;
 

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -16,7 +16,7 @@ Mode mode = CLIENT;
 mutex tlock;
 
 // For closing the sockets safely when Ctrl+C SIGINT is received
-void intHandler(int dummy) {
+void intHandler(int dummy __attribute__((unused))) {
   logger(INFO) << "Closing socket";
   mainSocket.closeSocket();
   exit(0);
@@ -24,7 +24,7 @@ void intHandler(int dummy) {
 
 // To ignore SIGPIPE being carried over to the parent
 // When client closes pipe
-void pipeHandler(int dummy) {
+void pipeHandler(int dummy __attribute__((unused))) {
   logger(INFO) << "Connection closed due to SIGPIPE";
   exit(0);
 }

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -43,7 +43,6 @@ int packetTunnel(struct tunnelContext *context) {
     ProxySocket& readSocket = context->readSocket;
     ProxySocket& writeSocket = context->writeSocket;
     const char* type = context->type;
-    volatile bool& otherHalfRunning = context->sleepOn;
     vector<char>& buffer = context->buffer;
 
     int failures = 0;
@@ -166,7 +165,7 @@ void printBanner() {
 }
 
 int main(int argc, char * argv[]) {
-    int portNumber, pid;
+    int portNumber;
 
     printBanner();
     signal(SIGINT, intHandler);

--- a/src/proxysocket.cpp
+++ b/src/proxysocket.cpp
@@ -57,9 +57,9 @@ ProxySocket::ProxySocket(char *host, int port, Protocol _outProto) {
 }
 
 int ProxySocket::write(vector<char> &buffer, int size, int& from) {
-    int bytesWritten;
+    int bytesWritten = 0;
     int headerBytes;
-    int i, retval, failures;
+    int retval, failures;
     bool connectionBroken = false;
     char tmp[200];
 
@@ -133,7 +133,6 @@ int ProxySocket::read(vector<char> &buffer, int from, int& respFrom) {
     int bytesRead = 0;
     int i, retval, failures;
     bool connectionBroken = false;
-    int contentLengthPosition = -1;
 
     if (protocol == PLAIN) {
         // Updating reference


### PR DESCRIPTION
- General cleanup of targets
- Add an install target
- Make sure CXXFLAGS are actually used, fix errors uncovered by `-Wall`
- Add `-Wextra`, fix unused parameter errors
- Add `-Wpedantic`, fix resulting macro expansion error by removing the macro